### PR TITLE
Add config generate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+main
+bin/
+.idea/*
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ main
 bin/
 .idea/*
 *.log
+/config.yml

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/chia-network/chia-tools/cmd"
+)
+
+// configCmd represents the config command
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Utilities for working with chia config",
+}
+
+func init() {
+	cmd.RootCmd.AddCommand(configCmd)
+}

--- a/cmd/config/generate.go
+++ b/cmd/config/generate.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"log"
 	"os"
 
@@ -42,8 +41,7 @@ var generateCmd = &cobra.Command{
 
 		out, err := yaml.Marshal(cfg)
 		if err != nil {
-			fmt.Printf("Error marshalling config: %s\n", err.Error())
-			os.Exit(1)
+			log.Fatalf("Error marshalling config: %s\n", err.Error())
 		}
 
 		err = os.WriteFile(viper.GetString("output"), out, 0655)

--- a/cmd/config/generate.go
+++ b/cmd/config/generate.go
@@ -26,6 +26,20 @@ var generateCmd = &cobra.Command{
 			log.Fatalln(err.Error())
 		}
 
+		valuesToSet := viper.GetStringMapString("set")
+		for path, value := range valuesToSet {
+			pathMap := config.ParsePathsFromStrings([]string{path}, false)
+			var key string
+			var pathSlice []string
+			for key, pathSlice = range pathMap {
+				break
+			}
+			err = cfg.SetFieldByPath(pathSlice, value)
+			if err != nil {
+				log.Fatalf("Error setting path `%s` to `%s`: %s\n", key, value, err.Error())
+			}
+		}
+
 		out, err := yaml.Marshal(cfg)
 		if err != nil {
 			fmt.Printf("Error marshalling config: %s\n", err.Error())
@@ -42,10 +56,14 @@ var generateCmd = &cobra.Command{
 func init() {
 	var (
 		outputFile string
+		setValues  map[string]string
 	)
 
 	generateCmd.PersistentFlags().StringVarP(&outputFile, "output", "o", "config.yml", "Output file for config")
+	generateCmd.PersistentFlags().StringToStringVarP(&setValues, "set", "s", nil, "Paths and values to set in the config")
+
 	cobra.CheckErr(viper.BindPFlag("output", generateCmd.PersistentFlags().Lookup("output")))
+	cobra.CheckErr(viper.BindPFlag("set", generateCmd.PersistentFlags().Lookup("set")))
 
 	configCmd.AddCommand(generateCmd)
 }

--- a/cmd/config/generate.go
+++ b/cmd/config/generate.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/chia-network/go-chia-libs/pkg/config"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 )
 
@@ -31,10 +32,20 @@ var generateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		os.WriteFile("config.yml", out, 0655)
+		err = os.WriteFile(viper.GetString("output"), out, 0655)
+		if err != nil {
+			log.Fatalln(err.Error())
+		}
 	},
 }
 
 func init() {
+	var (
+		outputFile string
+	)
+
+	generateCmd.PersistentFlags().StringVarP(&outputFile, "output", "o", "config.yml", "Output file for config")
+	cobra.CheckErr(viper.BindPFlag("output", generateCmd.PersistentFlags().Lookup("output")))
+
 	configCmd.AddCommand(generateCmd)
 }

--- a/cmd/config/generate.go
+++ b/cmd/config/generate.go
@@ -2,11 +2,12 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/chia-network/go-chia-libs/pkg/config"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // generateCmd generates a new chia config
@@ -14,13 +15,23 @@ var generateCmd = &cobra.Command{
 	Use:   "generate",
 	Short: "Generate a new chia configuration file",
 	Run: func(cmd *cobra.Command, args []string) {
-		cfg := config.ChiaConfig{}
+		cfg, err := config.LoadDefaultConfig()
+		if err != nil {
+			log.Fatalln(err.Error())
+		}
+
+		err = cfg.FillValuesFromEnvironment()
+		if err != nil {
+			log.Fatalln(err.Error())
+		}
+
 		out, err := yaml.Marshal(cfg)
 		if err != nil {
 			fmt.Printf("Error marshalling config: %s\n", err.Error())
 			os.Exit(1)
 		}
-		fmt.Print(string(out))
+
+		os.WriteFile("config.yml", out, 0655)
 	},
 }
 

--- a/cmd/config/generate.go
+++ b/cmd/config/generate.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/chia-network/go-chia-libs/pkg/config"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+// generateCmd generates a new chia config
+var generateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "Generate a new chia configuration file",
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg := config.ChiaConfig{}
+		out, err := yaml.Marshal(cfg)
+		if err != nil {
+			fmt.Printf("Error marshalling config: %s\n", err.Error())
+			os.Exit(1)
+		}
+		fmt.Printf(string(out))
+	},
+}
+
+func init() {
+	configCmd.AddCommand(generateCmd)
+}

--- a/cmd/config/generate.go
+++ b/cmd/config/generate.go
@@ -20,7 +20,7 @@ var generateCmd = &cobra.Command{
 			fmt.Printf("Error marshalling config: %s\n", err.Error())
 			os.Exit(1)
 		}
-		fmt.Printf(string(out))
+		fmt.Print(string(out))
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,8 +11,8 @@ import (
 
 var cfgFile string
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
+// RootCmd represents the base command when called without any subcommands
+var RootCmd = &cobra.Command{
 	Use:   "chia-tools",
 	Short: "Collection of CLI tools for working with Chia Blockchain",
 }
@@ -20,7 +20,7 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	err := rootCmd.Execute()
+	err := RootCmd.Execute()
 	if err != nil {
 		os.Exit(1)
 	}
@@ -29,7 +29,7 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.chia-tools.yaml)")
+	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.chia-tools.yaml)")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/chia-network/chia-tools
 go 1.22.4
 
 require (
-	github.com/chia-network/go-chia-libs v0.8.3-0.20240730222152-3b0bcd6a6205
+	github.com/chia-network/go-chia-libs v0.8.4
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,10 @@ module github.com/chia-network/chia-tools
 go 1.22.4
 
 require (
-	github.com/chia-network/go-chia-libs v0.8.2
+	github.com/chia-network/go-chia-libs v0.8.3
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -17,6 +18,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
+	github.com/samber/mo v1.13.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
@@ -28,6 +30,4 @@ require (
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/chia-network/chia-tools
 go 1.22.4
 
 require (
+	github.com/chia-network/go-chia-libs v0.8.2
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
 )
@@ -27,5 +28,6 @@ require (
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/chia-network/chia-tools
 go 1.22.4
 
 require (
-	github.com/chia-network/go-chia-libs v0.8.3
+	github.com/chia-network/go-chia-libs v0.8.3-0.20240730222152-3b0bcd6a6205
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/chia-network/go-chia-libs v0.8.2 h1:ExVs0LW/BZQNGCrDc1n7ixPmyka9MRNaLRWX/MNQ6MQ=
-github.com/chia-network/go-chia-libs v0.8.2/go.mod h1:qICIVdfTQg15wXb9soXMvZbXB2tYop7udSv+aZGBbwc=
+github.com/chia-network/go-chia-libs v0.8.3 h1:B/Ho8OUD9qr5duVuUeULvbnZ8iYRFzKoB45LJJ7XS60=
+github.com/chia-network/go-chia-libs v0.8.3/go.mod h1:npTqaFSjTdMxE7hc0LOmWJmWGqcs+IERarK5fDxXk/I=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -35,6 +35,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
+github.com/samber/mo v1.13.0 h1:LB1OwfJMju3a6FjghH+AIvzMG0ZPOzgTWj1qaHs1IQ4=
+github.com/samber/mo v1.13.0/go.mod h1:BfkrCPuYzVG3ZljnZB783WIJIGk1mcZr9c9CPf8tAxs=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
@@ -74,8 +76,6 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/chia-network/go-chia-libs v0.8.3 h1:B/Ho8OUD9qr5duVuUeULvbnZ8iYRFzKoB45LJJ7XS60=
-github.com/chia-network/go-chia-libs v0.8.3/go.mod h1:npTqaFSjTdMxE7hc0LOmWJmWGqcs+IERarK5fDxXk/I=
+github.com/chia-network/go-chia-libs v0.8.3-0.20240730222152-3b0bcd6a6205 h1:mDxjsfzxOa/voDTvNQz8aORpPl66SbbKpxSn7KFPOLY=
+github.com/chia-network/go-chia-libs v0.8.3-0.20240730222152-3b0bcd6a6205/go.mod h1:imCkBPLUOjqyvYV2XdYnef8EfeiDdZ8bfZCGvG4R1o0=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/chia-network/go-chia-libs v0.8.3-0.20240730222152-3b0bcd6a6205 h1:mDxjsfzxOa/voDTvNQz8aORpPl66SbbKpxSn7KFPOLY=
-github.com/chia-network/go-chia-libs v0.8.3-0.20240730222152-3b0bcd6a6205/go.mod h1:imCkBPLUOjqyvYV2XdYnef8EfeiDdZ8bfZCGvG4R1o0=
+github.com/chia-network/go-chia-libs v0.8.4 h1:8t9qXQljM8vuHTpkUi6JxUJz0Ne0TWE7KDZ/ELnn/KY=
+github.com/chia-network/go-chia-libs v0.8.4/go.mod h1:npTqaFSjTdMxE7hc0LOmWJmWGqcs+IERarK5fDxXk/I=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/chia-network/go-chia-libs v0.8.2 h1:ExVs0LW/BZQNGCrDc1n7ixPmyka9MRNaLRWX/MNQ6MQ=
+github.com/chia-network/go-chia-libs v0.8.2/go.mod h1:qICIVdfTQg15wXb9soXMvZbXB2tYop7udSv+aZGBbwc=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -72,6 +74,8 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,9 @@
 package main
 
-import "github.com/chia-network/chia-tools/cmd"
+import (
+	"github.com/chia-network/chia-tools/cmd"
+	_ "github.com/chia-network/chia-tools/cmd/config"
+)
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
`chia-tools config generate` is the basic command introduced here. The bare command does scaffold out a config, but the power is in the customizations below.

Note that the config that is generated for now has all yaml anchors expanded. I'll look into retaining anchors later.

## Customizing Config Values

The main thing this does is allow customizing the config easier (for use in docker/k8s, or other places where scripting this is useful)

### Via Flags

Set a path in the config and a value to set with `--set` or `-s`

`chia-tools config generate --set full_node.port=1234 --set full_node.rpc_port=7890`

### Via Env

Set environment variables that start with `chia.` to set values in a config file. This is particularly useful for docker/k8s where you can set env in the pod manifest or with docker run (`-e chia.full_node.port=58444`, etc)

Since most shells don't support `.` in environment variable names, `__` (double underscore) is also supported as the path separator

`chia.full_node.port=1234`
or 
`chia__full_node__port=1234`
