### PR TITLE
Handle windows case for the node not running in network switch

### DIFF
--- a/cmd/network/switch.go
+++ b/cmd/network/switch.go
@@ -14,6 +14,8 @@ import (
 	"github.com/chia-network/go-modules/pkg/slogs"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/chia-network/chia-tools/internal/connect"
 )
 
 var switchCmd = &cobra.Command{
@@ -304,7 +306,13 @@ func isConnectionRefused(err error) bool {
 		if netErr.Op == "dial" {
 			var syscallError *os.SyscallError
 			if errors.As(netErr.Err, &syscallError) {
-				return syscallError.Syscall == "connect" && errors.Is(syscallError.Err, syscall.ECONNREFUSED)
+				if syscallError.Syscall == "connect" && errors.Is(syscallError.Err, syscall.ECONNREFUSED) {
+					return true
+				}
+				// Handle Windows-specific case
+				if connect.IsWindowsConnectionRefused(err) {
+					return true
+				}
 			}
 		}
 	}

--- a/internal/connect/nonwindows_conn_refused.go
+++ b/internal/connect/nonwindows_conn_refused.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package connect
+
+// IsWindowsConnectionRefused is a no-op on non-Windows systems.
+func IsWindowsConnectionRefused(err error) bool {
+	return false
+}

--- a/internal/connect/windows_conn_refused.go
+++ b/internal/connect/windows_conn_refused.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package connect
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// IsWindowsConnectionRefused checks if the error is a Windows-specific connection refused error.
+func IsWindowsConnectionRefused(err error) bool {
+	return errors.Is(err, windows.WSAECONNREFUSED)
+}


### PR DESCRIPTION
The error on windows is different than linux/unix - and the syscall def doesn't exist except in windows, so add windows specific build files to make this work right