### PR TITLE
Add retry to trusted peer connections

### DIFF
--- a/cmd/config/addtrustedpeer.go
+++ b/cmd/config/addtrustedpeer.go
@@ -157,6 +157,7 @@ func getPeerID(cfg *config.ChiaConfig, chiaRoot string, ip net.IP, port uint16) 
 			peerprotocol.WithPeerPort(port),
 			peerprotocol.WithNetworkID(*cfg.SelectedNetwork),
 			peerprotocol.WithPeerKeyPair(*keypair),
+			peerprotocol.WithHandshakeTimeout(time.Second*3),
 		)
 		if err != nil {
 			if i == retries {

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	skipConfirm bool
+	retries     uint
 )
 
 // configCmd represents the config command

--- a/cmd/config/removetrustedpeer.go
+++ b/cmd/config/removetrustedpeer.go
@@ -149,5 +149,6 @@ func removeAllTrustedPeers(cfg *config.ChiaConfig) {
 func init() {
 	removeTrustedPeerCmd.Flags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip confirmation")
 	removeTrustedPeerCmd.Flags().BoolVarP(&removeAll, "all", "a", false, "Remove all trusted peers from the config file")
+	removeTrustedPeerCmd.Flags().UintVarP(&retries, "retries", "r", 3, "Number of times to retry connecting to the peer")
 	configCmd.AddCommand(removeTrustedPeerCmd)
 }


### PR DESCRIPTION
Also holds onto errors, when handling multiple peers, instead of failing right away.