### PR TITLE
Add coin splitting command that uses largest coin

### DIFF
--- a/cmd/coins/coins.go
+++ b/cmd/coins/coins.go
@@ -1,0 +1,17 @@
+package coins
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/chia-network/chia-tools/cmd"
+)
+
+// coinsCmd represents the coins command
+var coinsCmd = &cobra.Command{
+	Use:   "coins",
+	Short: "Utilities for working with chia coins",
+}
+
+func init() {
+	cmd.RootCmd.AddCommand(coinsCmd)
+}

--- a/cmd/coins/split-largest.go
+++ b/cmd/coins/split-largest.go
@@ -16,7 +16,7 @@ import (
 var splitLargestCmd = &cobra.Command{
 	Use:   "split-largest",
 	Short: "Find the largest coin in the wallet and split it into smaller coins",
-	Example: `chia-tools coins split-largest --fingerprint 123456789 --amount-per-coin 0.001 --number-of-coins 10
+	Example: `chia-tools coins split-largest --amount-per-coin 0.001 --number-of-coins 10
 chia-tools coins split-largest --id 1 --amount-per-coin 0.001 --number-of-coins 10 --fee 0.0001`,
 	Run: func(cmd *cobra.Command, args []string) {
 		amountPerCoinStr := viper.GetString("coins-amount-per-coin")
@@ -92,14 +92,6 @@ func SplitLargestCoin() {
 	}
 
 	walletID := viper.GetUint32("coins-wallet-id")
-	fingerprint := viper.GetInt("coins-fingerprint")
-
-	// If fingerprint is provided, we need to get the wallet ID
-	if fingerprint > 0 {
-		slogs.Logr.Debug("Getting wallet ID from fingerprint", "fingerprint", fingerprint)
-		// For now, we'll use the provided wallet ID directly
-		// In a full implementation, you might want to query available wallets
-	}
 
 	slogs.Logr.Debug("Getting spendable coins", "wallet_id", walletID)
 
@@ -200,7 +192,6 @@ func SplitLargestCoin() {
 }
 
 func init() {
-	splitLargestCmd.PersistentFlags().IntP("fingerprint", "f", 0, "Fingerprint of the wallet to use")
 	splitLargestCmd.PersistentFlags().StringP("amount-per-coin", "a", "", "The amount of each newly created coin, in XCH or CAT units")
 	splitLargestCmd.PersistentFlags().Uint32P("number-of-coins", "n", 0, "The number of coins we are creating")
 	splitLargestCmd.PersistentFlags().Uint32P("id", "i", 1, "Id of the wallet to use")
@@ -211,7 +202,6 @@ func init() {
 	cobra.CheckErr(splitLargestCmd.MarkPersistentFlagRequired("number-of-coins"))
 
 	// Bind flags to viper
-	cobra.CheckErr(viper.BindPFlag("coins-fingerprint", splitLargestCmd.PersistentFlags().Lookup("fingerprint")))
 	cobra.CheckErr(viper.BindPFlag("coins-amount-per-coin", splitLargestCmd.PersistentFlags().Lookup("amount-per-coin")))
 	cobra.CheckErr(viper.BindPFlag("coins-number-of-coins", splitLargestCmd.PersistentFlags().Lookup("number-of-coins")))
 	cobra.CheckErr(viper.BindPFlag("coins-wallet-id", splitLargestCmd.PersistentFlags().Lookup("id")))

--- a/cmd/coins/split-largest.go
+++ b/cmd/coins/split-largest.go
@@ -1,0 +1,221 @@
+package coins
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/chia-network/go-chia-libs/pkg/rpc"
+	"github.com/chia-network/go-chia-libs/pkg/types"
+	"github.com/chia-network/go-modules/pkg/slogs"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// splitLargestCmd represents the split-largest command
+var splitLargestCmd = &cobra.Command{
+	Use:   "split-largest",
+	Short: "Find the largest coin in the wallet and split it into smaller coins",
+	Example: `chia-tools coins split-largest --fingerprint 123456789 --amount-per-coin 0.001 --number-of-coins 10
+chia-tools coins split-largest --id 1 --amount-per-coin 0.001 --number-of-coins 10 --fee 0.0001`,
+	Run: func(cmd *cobra.Command, args []string) {
+		amountPerCoinStr := viper.GetString("coins-amount-per-coin")
+		numberOfCoins := viper.GetUint32("coins-number-of-coins")
+
+		if amountPerCoinStr == "" {
+			slogs.Logr.Fatal("amount-per-coin must be specified")
+		}
+		if numberOfCoins == 0 {
+			slogs.Logr.Fatal("number-of-coins must be greater than 0")
+		}
+
+		SplitLargestCoin()
+	},
+}
+
+// convertXCHToMojos converts a decimal XCH amount to mojos
+func convertXCHToMojos(xchStr string) (uint64, error) {
+	// Handle empty or zero values
+	if xchStr == "" || xchStr == "0" {
+		return 0, nil
+	}
+
+	// Remove any trailing zeros after decimal point for cleaner parsing
+	xchStr = strings.TrimRight(strings.TrimRight(xchStr, "0"), ".")
+
+	// If we end up with an empty string after trimming, it was just "0"
+	if xchStr == "" {
+		return 0, nil
+	}
+
+	// Split by decimal point
+	parts := strings.Split(xchStr, ".")
+	if len(parts) > 2 {
+		return 0, fmt.Errorf("invalid XCH amount format: %s", xchStr)
+	}
+
+	// Parse the whole number part
+	whole, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid whole number part: %s", parts[0])
+	}
+
+	// Convert to mojos (1 XCH = 1,000,000,000,000 mojos)
+	mojos := whole * 1000000000000
+
+	// If there's a decimal part, handle it
+	if len(parts) == 2 {
+		decimalPart := parts[1]
+		// Pad or truncate to 12 decimal places
+		if len(decimalPart) > 12 {
+			decimalPart = decimalPart[:12]
+		} else {
+			decimalPart = decimalPart + strings.Repeat("0", 12-len(decimalPart))
+		}
+
+		decimalMojos, err := strconv.ParseUint(decimalPart, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid decimal part: %s", parts[1])
+		}
+
+		mojos += decimalMojos
+	}
+
+	return mojos, nil
+}
+
+// SplitLargestCoin finds the largest coin in the wallet and splits it
+func SplitLargestCoin() {
+	client, err := rpc.NewClient(rpc.ConnectionModeHTTP, rpc.WithAutoConfig())
+	if err != nil {
+		slogs.Logr.Fatal("error creating chia RPC client", "error", err)
+	}
+
+	walletID := viper.GetUint32("coins-wallet-id")
+	fingerprint := viper.GetInt("coins-fingerprint")
+
+	// If fingerprint is provided, we need to get the wallet ID
+	if fingerprint > 0 {
+		slogs.Logr.Debug("Getting wallet ID from fingerprint", "fingerprint", fingerprint)
+		// For now, we'll use the provided wallet ID directly
+		// In a full implementation, you might want to query available wallets
+	}
+
+	slogs.Logr.Debug("Getting spendable coins", "wallet_id", walletID)
+
+	// Get spendable coins for the wallet
+	spendableCoins, _, err := client.WalletService.GetSpendableCoins(&rpc.GetSpendableCoinsOptions{
+		WalletID: walletID,
+	})
+	if err != nil {
+		slogs.Logr.Fatal("error getting spendable coins", "error", err)
+	}
+
+	if spendableCoins == nil || spendableCoins.ConfirmedRecords.IsAbsent() {
+		slogs.Logr.Fatal("no spendable coins found for wallet", "wallet_id", walletID)
+	}
+
+	records := spendableCoins.ConfirmedRecords.MustGet()
+	if len(records) == 0 {
+		slogs.Logr.Fatal("no spendable coins found in wallet", "wallet_id", walletID)
+	}
+
+	// Find the largest coin from the spendable coins
+	var largestCoin types.CoinRecord
+	largestAmount := uint64(0)
+
+	for _, record := range records {
+		if record.Coin.Amount > largestAmount {
+			largestAmount = record.Coin.Amount
+			largestCoin = record
+		}
+	}
+
+	if largestAmount == 0 {
+		slogs.Logr.Fatal("no coins with value found in wallet", "wallet_id", walletID)
+	}
+
+	coinID := largestCoin.Coin.ID().String()
+
+	slogs.Logr.Info("Found largest coin",
+		"coin_id", coinID,
+		"amount", largestCoin.Coin.Amount,
+		"wallet_id", walletID)
+
+	// Convert string amounts to mojos
+	amountPerCoinStr := viper.GetString("coins-amount-per-coin")
+	feeStr := viper.GetString("coins-fee")
+
+	amountPerCoin, err := convertXCHToMojos(amountPerCoinStr)
+	if err != nil {
+		slogs.Logr.Fatal("error converting amount-per-coin to mojos", "error", err)
+	}
+
+	fee, err := convertXCHToMojos(feeStr)
+	if err != nil {
+		slogs.Logr.Fatal("error converting fee to mojos", "error", err)
+	}
+
+	numberOfCoins := viper.GetUint32("coins-number-of-coins")
+
+	// Validate that we have enough in the coin to split
+	totalNeeded := amountPerCoin*uint64(numberOfCoins) + fee
+	if largestCoin.Coin.Amount < totalNeeded {
+		slogs.Logr.Fatal("largest coin does not have enough value for split",
+			"coin_amount", largestCoin.Coin.Amount,
+			"total_needed", totalNeeded,
+			"amount_per_coin", amountPerCoin,
+			"number_of_coins", numberOfCoins,
+			"fee", fee)
+	}
+
+	slogs.Logr.Info("Splitting coin",
+		"coin_id", coinID,
+		"amount_per_coin", amountPerCoin,
+		"number_of_coins", numberOfCoins,
+		"fee", fee)
+
+	// Split the coin
+	splitResponse, _, err := client.WalletService.SplitCoins(&rpc.SplitCoinsOptions{
+		WalletID:      walletID,
+		TargetCoinID:  coinID,
+		AmountPerCoin: amountPerCoin,
+		NumberOfCoins: numberOfCoins,
+		Fee:           fee,
+		Push:          true,
+	})
+	if err != nil {
+		slogs.Logr.Fatal("error splitting coin", "error", err)
+	}
+
+	if splitResponse == nil {
+		slogs.Logr.Fatal("no response from split_coins")
+	}
+
+	if splitResponse.TransactionID.IsPresent() {
+		fmt.Printf("Successfully split coin. Transaction ID: %s\n", splitResponse.TransactionID.MustGet())
+	} else {
+		fmt.Println("Coin split initiated successfully")
+	}
+}
+
+func init() {
+	splitLargestCmd.PersistentFlags().IntP("fingerprint", "f", 0, "Fingerprint of the wallet to use")
+	splitLargestCmd.PersistentFlags().StringP("amount-per-coin", "a", "", "The amount of each newly created coin, in XCH or CAT units")
+	splitLargestCmd.PersistentFlags().Uint32P("number-of-coins", "n", 0, "The number of coins we are creating")
+	splitLargestCmd.PersistentFlags().Uint32P("id", "i", 1, "Id of the wallet to use")
+	splitLargestCmd.PersistentFlags().StringP("fee", "m", "0", "Set the fees for the transaction, in XCH")
+
+	// Mark required flags
+	cobra.CheckErr(splitLargestCmd.MarkPersistentFlagRequired("amount-per-coin"))
+	cobra.CheckErr(splitLargestCmd.MarkPersistentFlagRequired("number-of-coins"))
+
+	// Bind flags to viper
+	cobra.CheckErr(viper.BindPFlag("coins-fingerprint", splitLargestCmd.PersistentFlags().Lookup("fingerprint")))
+	cobra.CheckErr(viper.BindPFlag("coins-amount-per-coin", splitLargestCmd.PersistentFlags().Lookup("amount-per-coin")))
+	cobra.CheckErr(viper.BindPFlag("coins-number-of-coins", splitLargestCmd.PersistentFlags().Lookup("number-of-coins")))
+	cobra.CheckErr(viper.BindPFlag("coins-wallet-id", splitLargestCmd.PersistentFlags().Lookup("id")))
+	cobra.CheckErr(viper.BindPFlag("coins-fee", splitLargestCmd.PersistentFlags().Lookup("fee")))
+
+	coinsCmd.AddCommand(splitLargestCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.24.1
 
 require (
-	github.com/chia-network/go-chia-libs v0.21.7
+	github.com/chia-network/go-chia-libs v0.21.8
 	github.com/chia-network/go-modules v0.0.9
 	github.com/spf13/cast v1.9.2
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/chia-network/go-chia-libs v0.21.7 h1:/5IdVSIFsbSYzXvPd6Q3PIYnz56d9rejd4hQoVWwK/E=
-github.com/chia-network/go-chia-libs v0.21.7/go.mod h1:+RMorskgxwYzPGf2gIyW0k7FGDdLrrH4X5ATrrMreb0=
+github.com/chia-network/go-chia-libs v0.21.8 h1:ARgNMNpBWvvfpfxjywDyObmNHs/b1p7wnICKwe9MDsA=
+github.com/chia-network/go-chia-libs v0.21.8/go.mod h1:+RMorskgxwYzPGf2gIyW0k7FGDdLrrH4X5ATrrMreb0=
 github.com/chia-network/go-modules v0.0.9 h1:9zC48Tsrw5jh1DMl6h0kbBL8A8daeeHVsnLxML6lTcg=
 github.com/chia-network/go-modules v0.0.9/go.mod h1:+cCfPV528ieagnMDkfZYp44cr3an/uBYUTfxzoFKhAg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/chia-network/chia-tools/cmd"
 	_ "github.com/chia-network/chia-tools/cmd/certs"
+	_ "github.com/chia-network/chia-tools/cmd/coins"
 	_ "github.com/chia-network/chia-tools/cmd/config"
 	_ "github.com/chia-network/chia-tools/cmd/datalayer"
 	_ "github.com/chia-network/chia-tools/cmd/debug"


### PR DESCRIPTION
Most of the time that I do coin splitting, I just want to take the largest coin in my wallet and split off a few smaller ones.  It is a hassle to find the coin ID of the largest coin and then provide that to the coin splitting command.  This command automates that for us - now if you do `chia-tools coins split-largest -f 00000000 -m 0.00000002 -n 2 -a 0.00033` it will find the largest coin and split off 2 coins worth 0.00033 XCH.  It takes the same flags as `chia wallet coin split` except the options have been reduced to pretty much just the amount, number of coins, and fees.  Here's the help output:

```
chia-tools coins split-largest -h                                         
Find the largest coin in the wallet and split it into smaller coins

Usage:
  chia-tools coins split-largest [flags]

Examples:
chia-tools coins split-largest --fingerprint 123456789 --amount-per-coin 0.001 --number-of-coins 10
chia-tools coins split-largest --id 1 --amount-per-coin 0.001 --number-of-coins 10 --fee 0.0001

Flags:
  -a, --amount-per-coin string   The amount of each newly created coin, in XCH or CAT units
  -m, --fee string               Set the fees for the transaction, in XCH (default "0")
  -f, --fingerprint int          Fingerprint of the wallet to use
  -h, --help                     help for split-largest
  -i, --id uint32                Id of the wallet to use (default 1)
  -n, --number-of-coins uint32   The number of coins we are creating

Global Flags:
      --dry-run            Show what changes would be made without actually making them. For commands that modify data or configuration, this will show the old and new values.
      --log-level string   The log-level for the application, can be one of info, warn, error, debug. (default "info")
```

Before this is merged, we'll need to update the go-chia-libs version that is pulled in after merging https://github.com/Chia-Network/go-chia-libs/pull/206      