### PR TITLE
Update go chia libs - pool_list bug fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.1
 
 require (
-	github.com/chia-network/go-chia-libs v0.24.0
+	github.com/chia-network/go-chia-libs v0.24.1
 	github.com/chia-network/go-modules v0.0.9
 	github.com/spf13/cast v1.10.0
 	github.com/spf13/cobra v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/chia-network/go-chia-libs v0.24.0 h1:XriLrpkH6hIj/W2yJf+irXhd+VR3vUm50+oOY4JkF6g=
-github.com/chia-network/go-chia-libs v0.24.0/go.mod h1:TYbjGcYWkFTJOFX0//xVHkToZ4Gs1qtZfDXArgnsiJc=
+github.com/chia-network/go-chia-libs v0.24.1 h1:keWUutj8r9mfLHGLv/AmmpW2e4b10kVxAieBYpT1JIE=
+github.com/chia-network/go-chia-libs v0.24.1/go.mod h1:TYbjGcYWkFTJOFX0//xVHkToZ4Gs1qtZfDXArgnsiJc=
 github.com/chia-network/go-modules v0.0.9 h1:9zC48Tsrw5jh1DMl6h0kbBL8A8daeeHVsnLxML6lTcg=
 github.com/chia-network/go-modules v0.0.9/go.mod h1:+cCfPV528ieagnMDkfZYp44cr3an/uBYUTfxzoFKhAg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update dependency `github.com/chia-network/go-chia-libs` from v0.24.0 to v0.24.1.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7010e86996831ab780bde031082e59fe9cddbd2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->