### PR TITLE
Update go chia libs to 0.24.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.1
 
 require (
-	github.com/chia-network/go-chia-libs v0.24.1
+	github.com/chia-network/go-chia-libs v0.24.2
 	github.com/chia-network/go-modules v0.0.9
 	github.com/spf13/cast v1.10.0
 	github.com/spf13/cobra v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/chia-network/go-chia-libs v0.24.1 h1:keWUutj8r9mfLHGLv/AmmpW2e4b10kVxAieBYpT1JIE=
-github.com/chia-network/go-chia-libs v0.24.1/go.mod h1:TYbjGcYWkFTJOFX0//xVHkToZ4Gs1qtZfDXArgnsiJc=
+github.com/chia-network/go-chia-libs v0.24.2 h1:1CHvXWLnjPCOeiX6j7OFHtmOqRY6ePfm27dTaBhy0e4=
+github.com/chia-network/go-chia-libs v0.24.2/go.mod h1:TYbjGcYWkFTJOFX0//xVHkToZ4Gs1qtZfDXArgnsiJc=
 github.com/chia-network/go-modules v0.0.9 h1:9zC48Tsrw5jh1DMl6h0kbBL8A8daeeHVsnLxML6lTcg=
 github.com/chia-network/go-modules v0.0.9/go.mod h1:+cCfPV528ieagnMDkfZYp44cr3an/uBYUTfxzoFKhAg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps github.com/chia-network/go-chia-libs to v0.24.2 and updates go.sum.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62d1dfd2fd3d52fcffef8f7a7ccddceb0cbec3aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->