### PR TITLE
Update go chia libs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.1
 
 require (
-	github.com/chia-network/go-chia-libs v1.2.0
+	github.com/chia-network/go-chia-libs v1.2.1
 	github.com/chia-network/go-modules v0.0.9
 	github.com/spf13/cast v1.10.0
 	github.com/spf13/cobra v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/chia-network/go-chia-libs v1.2.0 h1:NcNfmi04x/xllJfLRJWozOCUyuAHJv/53AJFB0gFwG0=
-github.com/chia-network/go-chia-libs v1.2.0/go.mod h1:2Ud+G6/JdMruQol9Jg8dEe9BvEeDXV0lUXJayT1ujHQ=
+github.com/chia-network/go-chia-libs v1.2.1 h1:LUuUI8cpAWrqjMeMwj2/r2bdtha6UlAoLJcVPIf2r4s=
+github.com/chia-network/go-chia-libs v1.2.1/go.mod h1:2Ud+G6/JdMruQol9Jg8dEe9BvEeDXV0lUXJayT1ujHQ=
 github.com/chia-network/go-modules v0.0.9 h1:9zC48Tsrw5jh1DMl6h0kbBL8A8daeeHVsnLxML6lTcg=
 github.com/chia-network/go-modules v0.0.9/go.mod h1:+cCfPV528ieagnMDkfZYp44cr3an/uBYUTfxzoFKhAg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates dependency versions.
> 
> - Bumps `github.com/chia-network/go-chia-libs` from `v1.2.0` to `v1.2.1` in `go.mod` and `go.sum`
> 
> *No application code changes.*
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2267b681aa898da214e6637638f7774999650aed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->