### PR TITLE
Update go chia libs to 1.2.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.1
 
 require (
-	github.com/chia-network/go-chia-libs v1.2.1
+	github.com/chia-network/go-chia-libs v1.2.2
 	github.com/chia-network/go-modules v0.0.9
 	github.com/spf13/cast v1.10.0
 	github.com/spf13/cobra v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/chia-network/go-chia-libs v1.2.1 h1:LUuUI8cpAWrqjMeMwj2/r2bdtha6UlAoLJcVPIf2r4s=
-github.com/chia-network/go-chia-libs v1.2.1/go.mod h1:2Ud+G6/JdMruQol9Jg8dEe9BvEeDXV0lUXJayT1ujHQ=
+github.com/chia-network/go-chia-libs v1.2.2 h1:va+Ad9eF7XiKfDivbOFme631RCI6s8S6RZaOIQ45jpk=
+github.com/chia-network/go-chia-libs v1.2.2/go.mod h1:2Ud+G6/JdMruQol9Jg8dEe9BvEeDXV0lUXJayT1ujHQ=
 github.com/chia-network/go-modules v0.0.9 h1:9zC48Tsrw5jh1DMl6h0kbBL8A8daeeHVsnLxML6lTcg=
 github.com/chia-network/go-modules v0.0.9/go.mod h1:+cCfPV528ieagnMDkfZYp44cr3an/uBYUTfxzoFKhAg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency-only version bump with no code changes in this repo; risk is limited to potential upstream behavioral changes in `go-chia-libs`.
> 
> **Overview**
> Updates the `github.com/chia-network/go-chia-libs` dependency from `v1.2.1` to `v1.2.2`, updating the corresponding `go.sum` checksums.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e4e17130dc34b0de773f2a8920a349031a56927. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->