### PR TITLE
Log detected chia environment variables before applying them to config

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,6 +1,10 @@
 package config
 
 import (
+	"os"
+	"strings"
+
+	"github.com/chia-network/go-modules/pkg/slogs"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -11,6 +15,21 @@ var (
 	skipConfirm bool
 	retries     uint
 )
+
+// logDetectedChiaEnvVars scans the process environment for variables prefixed
+// with "chia." or "chia__" and logs each one so the user knows which env vars
+// will be applied to the config before --set flags are processed.
+func logDetectedChiaEnvVars() {
+	for _, env := range os.Environ() {
+		for _, prefix := range []string{"chia.", "chia__"} {
+			if strings.HasPrefix(env, prefix) {
+				name, _, _ := strings.Cut(env, "=")
+				slogs.Logr.Info("Detected chia environment variable that will be applied to config", "env_var", name)
+				break
+			}
+		}
+	}
+}
 
 // configCmd represents the config command
 var configCmd = &cobra.Command{

--- a/cmd/config/edit.go
+++ b/cmd/config/edit.go
@@ -46,9 +46,10 @@ chia-tools config edit --set full_node.port=58444 --dry-run`,
 			cfg.SetIndependentLogging()
 		}
 
+		logDetectedChiaEnvVars()
 		err = cfg.FillValuesFromEnvironment()
 		if err != nil {
-			slogs.Logr.Fatal("error filling values from environment", "error", err)
+			slogs.Logr.Fatal("error applying chia environment variables to config. Check the environment variables listed above for incorrect values", "error", err)
 		}
 
 		dryRun := viper.GetBool("dry-run")

--- a/cmd/config/generate.go
+++ b/cmd/config/generate.go
@@ -21,9 +21,10 @@ var generateCmd = &cobra.Command{
 			slogs.Logr.Fatal("error loading default config", "error", err)
 		}
 
+		logDetectedChiaEnvVars()
 		err = cfg.FillValuesFromEnvironment()
 		if err != nil {
-			slogs.Logr.Fatal("error filling values from environment", "error", err)
+			slogs.Logr.Fatal("error applying chia environment variables to config. Check the environment variables listed above for incorrect values", "error", err)
 		}
 
 		valuesToSet := viper.GetStringMapString("set")


### PR DESCRIPTION
## Summary

- Adds `logDetectedChiaEnvVars()` which scans the process environment for `chia.`/`chia__` prefixed variables and logs their names before `FillValuesFromEnvironment()` runs
- Updates the error message in both `config edit` and `config generate` to direct the user to check the listed environment variables
- Addresses confusion when a user runs `--set` but the error actually comes from a stale or malformed environment variable

### Before
```
level=ERROR msg="error filling values from environment" error="failed to unmarshal yaml into field: ..."
```

### After
```
level=INFO  msg="Detected chia environment variable that will be applied to config" env_var=chia__pool__pool_list
level=ERROR msg="error applying chia environment variables to config. Check the environment variables listed above for incorrect values" error="failed to unmarshal yaml into field: ..."
```

## Test plan
- [ ] Run `config edit` with no chia env vars set — no extra log output expected
- [ ] Run with a valid chia env var (e.g. `chia__full_node__port=8444`) — should log the var name and apply it successfully
- [ ] Run with a malformed chia env var — should log the var name, then show the improved error message pointing at it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds pre-flight logging and tweaks fatal error strings around environment-to-config application without changing config mutation logic.
> 
> **Overview**
> Adds `logDetectedChiaEnvVars()` to enumerate and log any `chia.`/`chia__` environment variables that will be applied to configuration.
> 
> Runs this logging step in both `config edit` and `config generate` immediately before `FillValuesFromEnvironment()`, and updates the failure message to point users to the logged env vars when env-driven config parsing fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7508e017e343a8048bb7e79e4014934a8ce23075. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->