### PR TITLE
Update Managed Files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -70,7 +70,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/\\.github/workflows/.+$/"],
       "matchStrings": ["NODELOCALDNS_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
-      "depNameTemplate": "kubernetes/dns",
+      "depNameTemplate": "kubernetes-sigs/node-local-dns",
       "datasourceTemplate": "github-tags"
     },
     {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change that just retargets Renovate’s lookup for `NODELOCALDNS_VERSION`; the main impact is on automated dependency update PRs.
> 
> **Overview**
> Updates `renovate.json` so the custom regex manager for `NODELOCALDNS_VERSION` tracks the dependency as `kubernetes-sigs/node-local-dns` instead of `kubernetes/dns`, ensuring Renovate pulls tags from the correct GitHub repository.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c71ba926c5849eab20d461ecd998d06ae816d681. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->