### PR TITLE
Update Managed Files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,13 +62,16 @@ $(TEST_TARGETS): test
 check test tests: fmt lint vet staticcheck errcheck vulncheck; $(info $(M) running $(NAME:%=% )tests…) @ ## Run tests
 	$Q $(GO) test -timeout $(TIMEOUT)s $(ARGS) $(TESTPKGS)
 
-.PHONY: lint
-lint: | $(GOLINT) ; $(info $(M) running golint…) @ ## Run golint
-	$Q $(GOLINT) -set_exit_status $(PKGS)
-
 .PHONY: fmt
 fmt: ; $(info $(M) running gofmt…) @ ## Run gofmt on all source files
 	$Q $(GO) fmt $(PKGS)
+
+# Run fmt before any linter so parallel `-jN` doesn't change files while a linter is mid flight.
+lint vet staticcheck errcheck vulncheck: fmt
+
+.PHONY: lint
+lint: | $(GOLINT) ; $(info $(M) running golint…) @ ## Run golint
+	$Q $(GOLINT) -set_exit_status $(PKGS)
 
 .PHONY: vet
 vet: ; $(info $(M) running go vet…) @ ## Run go vet on all source files


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk Makefile-only change that just adds ordering between `fmt` and linting targets. Main impact is slightly longer local/CI runs due to `fmt` being forced before linters.
> 
> **Overview**
> Updates the `Makefile` so `fmt` is a prerequisite for `lint`, `vet`, `staticcheck`, `errcheck`, and `vulncheck`, preventing parallel `make -j` runs from formatting files while linters are running.
> 
> Reorders the `lint` target definition accordingly; no Go code or tool behavior changes beyond the enforced execution order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1f14ad052d06fdca77cea35d849ae1e07483938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->